### PR TITLE
Fix parsed opaque URL to contain Path

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -126,11 +126,11 @@ func (g *Gitlab) ResourceUrlRaw(u string, params map[string]string) (string, str
 
 	path := u
 	u = g.BaseUrl + g.ApiPath + path + "?private_token=" + g.Token
-	p, err := url.Parse(u)
+	p, err := url.Parse(g.BaseUrl)
 	if err != nil {
 		return u, ""
 	}
-	opaque := "//" + p.Host + g.ApiPath + path
+	opaque := "//" + p.Host + p.Path + g.ApiPath + path
 
 	return u, opaque
 }

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -11,3 +11,19 @@ func TestResourceUrl(t *testing.T) {
 	assert.Equal(t, gitlab.ResourceUrl(projects_url, nil), "http://base_url/api_path/projects?private_token=token")
 	assert.Equal(t, gitlab.ResourceUrl(project_url, map[string]string{":id": "123"}), "http://base_url/api_path/projects/123?private_token=token")
 }
+
+func TestResourceUrlRaw(t *testing.T) {
+	gitlab := NewGitlab("http://base_url/", "api_path", "token")
+	u, opaque := gitlab.ResourceUrlRaw(projects_url, map[string]string{":id": "123"})
+	assert.Equal(t, u, "http://base_url/api_path/projects?private_token=token")
+	assert.Equal(t, opaque, "//base_url/api_path/projects")
+
+	gitlab = NewGitlab("http://base/url/", "api_path", "token")
+	u, opaque = gitlab.ResourceUrlRaw(projects_url, nil)
+	assert.Equal(t, u, "http://base/url/api_path/projects?private_token=token")
+	assert.Equal(t, opaque, "//base/url/api_path/projects")
+
+	u, opaque = gitlab.ResourceUrlRaw(projects_url, map[string]string{":id": "123"})
+	assert.Equal(t, u, "http://base/url/api_path/projects?private_token=token")
+	assert.Equal(t, opaque, "//base/url/api_path/projects")
+}


### PR DESCRIPTION
Example: On @drone, use http://example.com/foo as Gitlab URL, http://example.com/ is used.
