### PR TITLE
change hCommit.Timestamp to time.Time type

### DIFF
--- a/hook_payload.go
+++ b/hook_payload.go
@@ -38,11 +38,11 @@ type hRepository struct {
 }
 
 type hCommit struct {
-	Id        string  `json:"id,omitempty"`
-	Message   string  `json:"message,omitempty"`
-	Timestamp string  `json:"timestamp,omitempty"`
-	URL       string  `json:"url,omitempty"`
-	Author    *Person `json:"author,omitempty"`
+	Id        string    `json:"id,omitempty"`
+	Message   string    `json:"message,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	URL       string    `json:"url,omitempty"`
+	Author    *Person   `json:"author,omitempty"`
 }
 
 type HookPayload struct {


### PR DESCRIPTION
Go automatically figures out the time layout. Tested with the latest Gitlab version and on Go 1.4.