### PR TITLE
add merge_status to struct

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -31,6 +31,7 @@ type MergeRequest struct {
 	Assignee       *User  `json:"assignee,omitempty"`
 	Description    string `json:"description,omitempty"`
 	WorkInProgress bool   `json:"work_in_progress,omitempty"`
+	MergeStatus    string `json:"merge_status,omitempty"`
 }
 
 type ChangeItem struct {


### PR DESCRIPTION
Adds the MergeStatus field which will give information on whether or not a merge request has conflicts.