### PR TITLE
add assertions, add source and project ID to JSON, tests, and struct

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -16,22 +16,24 @@ const (
 )
 
 type MergeRequest struct {
-	Id             int    `json:"id,omitempty"`
-	Iid            int    `json:"iid,omitempty"`
-	TargetBranch   string `json:"target_branch,omitempty"`
-	SourceBranch   string `json:"source_branch,omitempty"`
-	ProjectId      int    `json:"project_id,omitempty"`
-	Title          string `json:"title,omitempty"`
-	State          string `json:"state,omitempty"`
-	CreatedAt      string `json:"created_at,omitempty"`
-	UpdatedAt      string `json:"updated_at,omitempty"`
-	Upvotes        int    `json:"upvotes,omitempty"`
-	Downvotes      int    `json:"downvotes,omitempty"`
-	Author         *User  `json:"author,omitempty"`
-	Assignee       *User  `json:"assignee,omitempty"`
-	Description    string `json:"description,omitempty"`
-	WorkInProgress bool   `json:"work_in_progress,omitempty"`
-	MergeStatus    string `json:"merge_status,omitempty"`
+	Id              int    `json:"id,omitempty"`
+	Iid             int    `json:"iid,omitempty"`
+	TargetBranch    string `json:"target_branch,omitempty"`
+	SourceBranch    string `json:"source_branch,omitempty"`
+	ProjectId       int    `json:"project_id,omitempty"`
+	Title           string `json:"title,omitempty"`
+	State           string `json:"state,omitempty"`
+	CreatedAt       string `json:"created_at,omitempty"`
+	UpdatedAt       string `json:"updated_at,omitempty"`
+	Upvotes         int    `json:"upvotes,omitempty"`
+	Downvotes       int    `json:"downvotes,omitempty"`
+	Author          *User  `json:"author,omitempty"`
+	Assignee        *User  `json:"assignee,omitempty"`
+	Description     string `json:"description,omitempty"`
+	WorkInProgress  bool   `json:"work_in_progress,omitempty"`
+	MergeStatus     string `json:"merge_status,omitempty"`
+	SourceProjectID string `json:"source_project_id,omitempty"`
+	TargetProjectID string `json:"target_project_id,omitempty"`
 }
 
 type ChangeItem struct {

--- a/merge_requests_test.go
+++ b/merge_requests_test.go
@@ -1,8 +1,9 @@
 package gogitlab
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProjectMergeRequests(t *testing.T) {
@@ -20,6 +21,9 @@ func TestProjectMergeRequest(t *testing.T) {
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, mr.TargetBranch, "master")
+	assert.Equal(t, mr.MergeStatus, "can_be_merged")
+	assert.Equal(t, mr.SourceProjectID, "2")
+	assert.Equal(t, mr.TargetProjectID, "3")
 	defer ts.Close()
 }
 

--- a/stubs/merge_requests/show.json
+++ b/stubs/merge_requests/show.json
@@ -26,6 +26,9 @@
     "state": "active",
     "created_at": "2012-04-29T08:46:00Z"
   },
+  "source_project_id": "2",
+  "target_project_id": "3",
   "description":"fixed login page css paddings",
-  "work_in_progress": false
+  "work_in_progress": false,
+  "merge_status": "can_be_merged"
 }


### PR DESCRIPTION
This pull request adds support for Source and Target Project IDs. This allows the user of the library to get project information about merge requests from forks (as opposed to just merge requests within the same repo).