### PR TITLE
Feature/fix source target project id types

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -16,21 +16,24 @@ const (
 )
 
 type MergeRequest struct {
-	Id             int    `json:"id,omitempty"`
-	Iid            int    `json:"iid,omitempty"`
-	TargetBranch   string `json:"target_branch,omitempty"`
-	SourceBranch   string `json:"source_branch,omitempty"`
-	ProjectId      int    `json:"project_id,omitempty"`
-	Title          string `json:"title,omitempty"`
-	State          string `json:"state,omitempty"`
-	CreatedAt      string `json:"created_at,omitempty"`
-	UpdatedAt      string `json:"updated_at,omitempty"`
-	Upvotes        int    `json:"upvotes,omitempty"`
-	Downvotes      int    `json:"downvotes,omitempty"`
-	Author         *User  `json:"author,omitempty"`
-	Assignee       *User  `json:"assignee,omitempty"`
-	Description    string `json:"description,omitempty"`
-	WorkInProgress bool   `json:"work_in_progress,omitempty"`
+	Id              int    `json:"id,omitempty"`
+	Iid             int    `json:"iid,omitempty"`
+	TargetBranch    string `json:"target_branch,omitempty"`
+	SourceBranch    string `json:"source_branch,omitempty"`
+	ProjectId       int    `json:"project_id,omitempty"`
+	Title           string `json:"title,omitempty"`
+	State           string `json:"state,omitempty"`
+	CreatedAt       string `json:"created_at,omitempty"`
+	UpdatedAt       string `json:"updated_at,omitempty"`
+	Upvotes         int    `json:"upvotes,omitempty"`
+	Downvotes       int    `json:"downvotes,omitempty"`
+	Author          *User  `json:"author,omitempty"`
+	Assignee        *User  `json:"assignee,omitempty"`
+	Description     string `json:"description,omitempty"`
+	WorkInProgress  bool   `json:"work_in_progress,omitempty"`
+	MergeStatus     string `json:"merge_status,omitempty"`
+	SourceProjectID int    `json:"source_project_id,omitempty"`
+	TargetProjectID int    `json:"target_project_id,omitempty"`
 }
 
 type ChangeItem struct {

--- a/merge_requests_test.go
+++ b/merge_requests_test.go
@@ -1,8 +1,9 @@
 package gogitlab
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProjectMergeRequests(t *testing.T) {
@@ -20,6 +21,9 @@ func TestProjectMergeRequest(t *testing.T) {
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, mr.TargetBranch, "master")
+	assert.Equal(t, mr.MergeStatus, "can_be_merged")
+	assert.Equal(t, mr.SourceProjectID, 2)
+	assert.Equal(t, mr.TargetProjectID, 3)
 	defer ts.Close()
 }
 

--- a/stubs/merge_requests/show.json
+++ b/stubs/merge_requests/show.json
@@ -26,6 +26,9 @@
     "state": "active",
     "created_at": "2012-04-29T08:46:00Z"
   },
+  "source_project_id": 2,
+  "target_project_id": 3,
   "description":"fixed login page css paddings",
-  "work_in_progress": false
+  "work_in_progress": false,
+  "merge_status": "can_be_merged"
 }


### PR DESCRIPTION
So it turns out that GitLab API is inconsistent! On their [Merge Requests](http://docs.gitlab.com/ee/api/merge_requests.html) API page:

Half the time we have strings:
```
  "source_project_id": "3",
  "target_project_id": "4",
```
And the other half of the time we have ints:
```
  "source_project_id": 3,
  "target_project_id": 4,
```

After testing the actual endpoint, I've been getting ints. So I have made this PR to change the types of the following fields of Merge Requests to ints:

- `SourceProjectID`
- `TargetProjectID`

Sorry!