### PR TITLE
fix(request) add application/json content-type header to POST/PUT req…

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -79,6 +79,10 @@ func (g *Gitlab) execRequest(method, url string, body []byte) (*http.Response, e
 		req, err = http.NewRequest(method, url, nil)
 	}
 
+	if method == "POST" || method == "PUT" {
+		req.Header.Add("Content-Type", "application/json")
+	}
+
 	if err != nil {
 		panic("Error while building gitlab request")
 	}
@@ -142,6 +146,11 @@ func (g *Gitlab) buildAndExecRequestRaw(method, url, opaque string, body []byte)
 	} else {
 		req, err = http.NewRequest(method, url, nil)
 	}
+
+	if method == "POST" || method == "PUT" {
+		req.Header.Add("Content-Type", "application/json")
+	}
+
 	if err != nil {
 		panic("Error while building gitlab request")
 	}


### PR DESCRIPTION
…uests

This fix affects all POST/PUT requests. Gitlab currently ignores
the body of POST/PUT requests when the content-type header is not set.

Even though the response status is 200, the requests have no effect on
Gitlab.