### PR TITLE
Add pipeline webhook payload support

### DIFF
--- a/builds.go
+++ b/builds.go
@@ -23,7 +23,7 @@ type ArtifactsFile struct {
 type Build struct {
 	Id            int           `json:"id"`
 	ArtifactsFile ArtifactsFile `json:"artifacts_file"`
-	Commit        Commit        `json:"commit"`
+	Commit        Commit        `json:"commit,omitempty"`
 	CreatedAt     string        `json:"created_at"`
 	DownloadURL   string        `json:"download_url"`
 	FinishedAt    string        `json:"finished_at"`
@@ -34,6 +34,8 @@ type Build struct {
 	Status        string        `json:"status"`
 	Tag           bool          `json:"tag"`
 	User          User          `json:"user"`
+	When          string        `json:"when,omitempty"`
+	Manual        bool          `json:"manual,omitempty"`
 }
 
 func (g *Gitlab) ProjectBuilds(id string) ([]*Build, error) {

--- a/hook_payload.go
+++ b/hook_payload.go
@@ -75,6 +75,7 @@ type HookPayload struct {
 	TotalCommitsCount int          `json:"total_commits_count,omitempty"`
 	ObjectKind        string       `json:"object_kind,omitempty"`
 	ObjectAttributes  *HookObjAttr `json:"object_attributes,omitempty"`
+	Builds            []*Build     `json:"builds,omitempty"`
 }
 
 // ParseHook parses hook payload from GitLab

--- a/hook_payload.go
+++ b/hook_payload.go
@@ -9,12 +9,20 @@ import (
 
 type HookObjAttr struct {
 	Id              int       `json:"id,omitempty"`
+	Ref             string    `json:"ref,omitempty"`
+	Tag             bool      `json:"tag,omitempty"`
+	Sha             string    `json:"sha,omitempty"`
+	BeforeSha       string    `json:"before_sha,omitempty"`
 	Title           string    `json:"title,omitempty"`
 	AssigneeId      int       `json:"assignee_id,omitempty"`
 	AuthorId        int       `json:"author_id,omitempty"`
 	ProjectId       int       `json:"project_id,omitempty"`
+	Status          string    `json:"status,omitempty"`
+	Stages          []string  `json:"stages,omitempty"`
 	CreatedAt       time.Time `json:"created_at,omitempty"`
 	UpdatedAt       time.Time `json:"updated_at,omitempty"`
+	FinishedAt      time.Time `json:"finished_at,omitempty"`
+	Duration        int       `json:"duration,omitempty"`
 	Position        int       `json:"position,omitempty"`
 	BranchName      string    `json:"branch_name,omitempty"`
 	Description     string    `json:"description,omitempty"`
@@ -37,6 +45,14 @@ type hRepository struct {
 	Homepage    string `json:"homepage,omitempty"`
 }
 
+type hProject struct {
+	Project
+	// Overwrite type *gogitlab.Namespace with type string,
+	// otherwise the project hash passed for pipeline hooks is
+	// identical
+	Namespace string `json:"namespace,omitempty"`
+}
+
 type hCommit struct {
 	Id        string    `json:"id,omitempty"`
 	Message   string    `json:"message,omitempty"`
@@ -52,8 +68,10 @@ type HookPayload struct {
 	UserId            int          `json:"user_id,omitempty"`
 	UserName          string       `json:"user_name,omitempty"`
 	ProjectId         int          `json:"project_id,omitempty"`
+	Project           *hProject    `json:"project,omitempty"`
 	Repository        *hRepository `json:"repository,omitempty"`
 	Commits           []hCommit    `json:"commits,omitempty"`
+	Commit            *hCommit     `json:"commit,omitempty"`
 	TotalCommitsCount int          `json:"total_commits_count,omitempty"`
 	ObjectKind        string       `json:"object_kind,omitempty"`
 	ObjectAttributes  *HookObjAttr `json:"object_attributes,omitempty"`
@@ -73,6 +91,8 @@ func ParseHook(payload []byte) (*HookPayload, error) {
 		if len(hp.After) == 0 {
 			return nil, fmt.Errorf("Invalid hook received, commit hash not found.")
 		}
+	case hp.ObjectKind == "pipeline":
+		fallthrough
 	case hp.ObjectKind == "issue":
 		fallthrough
 	case hp.ObjectKind == "merge_request":

--- a/hook_payload.go
+++ b/hook_payload.go
@@ -106,10 +106,16 @@ func ParseHook(payload []byte) (*HookPayload, error) {
 	return &hp, nil
 }
 
-// Branch returns current branch for push event hook payload
+// Branch returns current branch for pipeline and push event hook
+// payload
 // This function returns empty string for any other events
 func (h *HookPayload) Branch() string {
-	return strings.TrimPrefix(h.Ref, "refs/heads/")
+	ref := h.Ref
+	if h.ObjectAttributes != nil && len(h.ObjectAttributes.Ref) > 0 {
+		ref = h.ObjectAttributes.Ref
+	}
+
+	return strings.TrimPrefix(ref, "refs/heads/")
 }
 
 // Head returns the latest changeset for push event hook payload

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -49,3 +49,16 @@ func TestParseMergeRequestHook(t *testing.T) {
 	assert.Equal(t, p.ObjectAttributes.TargetBranch, "master")
 	assert.Equal(t, p.ObjectAttributes.SourceProjectId, p.ObjectAttributes.TargetProjectId)
 }
+
+func TestParsePipelineHook(t *testing.T) {
+	stub, _ := ioutil.ReadFile("stubs/hooks/pipeline.json")
+	p, err := ParseHook([]byte(stub))
+
+	assert.Equal(t, err, nil)
+	assert.IsType(t, new(HookPayload), p)
+	assert.Equal(t, p.ObjectAttributes.Sha, "bcbb5ec396a2c0f828686f14fac9b80b780504f2")
+	assert.Equal(t, p.Project.Description, "Atque in sunt eos similique dolores voluptatem.")
+	assert.Equal(t, p.Commit.Id, "bcbb5ec396a2c0f828686f14fac9b80b780504f2")
+	assert.Equal(t, p.Branch(), "master")
+	assert.Equal(t, p.Builds[0].Id, 380)
+}

--- a/stubs/hooks/pipeline.json
+++ b/stubs/hooks/pipeline.json
@@ -1,0 +1,153 @@
+{
+    "object_kind": "pipeline",
+    "object_attributes":{
+	"id": 31,
+	"ref": "master",
+	"tag": false,
+	"sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
+	"before_sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
+	"status": "success",
+	"stages":[
+	    "build",
+	    "test",
+	    "deploy"
+	],
+	"created_at": "2016-08-12T15:23:28Z",
+	"finished_at": "2016-08-12T15:26:29Z",
+	"duration": 63
+    },
+    "user":{
+	"name": "Administrator",
+	"username": "root",
+	"avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
+    },
+    "project":{
+	"name": "Gitlab Test",
+	"description": "Atque in sunt eos similique dolores voluptatem.",
+	"web_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test",
+	"avatar_url": null,
+	"git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
+	"git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
+	"namespace": "Gitlab Org",
+	"visibility_level": 20,
+	"path_with_namespace": "gitlab-org/gitlab-test",
+	"default_branch": "master"
+    },
+    "commit":{
+	"id": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
+	"message": "test\n",
+	"timestamp": "2016-08-12T17:23:21+02:00",
+	"url": "http://example.com/gitlab-org/gitlab-test/commit/bcbb5ec396a2c0f828686f14fac9b80b780504f2",
+	"author":{
+	    "name": "User",
+	    "email": "user@gitlab.com"
+	}
+    },
+    "builds":[
+	{
+	    "id": 380,
+	    "stage": "deploy",
+	    "name": "production",
+	    "status": "skipped",
+	    "created_at": "2016-08-12 15:23:28 UTC",
+	    "started_at": null,
+	    "finished_at": null,
+	    "when": "manual",
+	    "manual": true,
+	    "user":{
+		"name": "Administrator",
+		"username": "root",
+		"avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
+	    },
+	    "runner": null,
+	    "artifacts_file":{
+		"filename": null,
+		"size": null
+	    }
+	},
+	{
+	    "id": 377,
+	    "stage": "test",
+	    "name": "test-image",
+	    "status": "success",
+	    "created_at": "2016-08-12 15:23:28 UTC",
+	    "started_at": "2016-08-12 15:26:12 UTC",
+	    "finished_at": null,
+	    "when": "on_success",
+	    "manual": false,
+	    "user":{
+		"name": "Administrator",
+		"username": "root",
+		"avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
+	    },
+	    "runner": null,
+	    "artifacts_file":{
+		"filename": null,
+		"size": null
+	    }
+	},
+	{
+	    "id": 378,
+	    "stage": "test",
+	    "name": "test-build",
+	    "status": "success",
+	    "created_at": "2016-08-12 15:23:28 UTC",
+	    "started_at": "2016-08-12 15:26:12 UTC",
+	    "finished_at": "2016-08-12 15:26:29 UTC",
+	    "when": "on_success",
+	    "manual": false,
+	    "user":{
+		"name": "Administrator",
+		"username": "root",
+		"avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
+	    },
+	    "runner": null,
+	    "artifacts_file":{
+		"filename": null,
+		"size": null
+	    }
+	},
+	{
+	    "id": 376,
+	    "stage": "build",
+	    "name": "build-image",
+	    "status": "success",
+	    "created_at": "2016-08-12 15:23:28 UTC",
+	    "started_at": "2016-08-12 15:24:56 UTC",
+	    "finished_at": "2016-08-12 15:25:26 UTC",
+	    "when": "on_success",
+	    "manual": false,
+	    "user":{
+		"name": "Administrator",
+		"username": "root",
+		"avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
+	    },
+	    "runner": null,
+	    "artifacts_file":{
+		"filename": null,
+		"size": null
+	    }
+	},
+	{
+	    "id": 379,
+	    "stage": "deploy",
+	    "name": "staging",
+	    "status": "created",
+	    "created_at": "2016-08-12 15:23:28 UTC",
+	    "started_at": null,
+	    "finished_at": null,
+	    "when": "on_success",
+	    "manual": false,
+	    "user":{
+		"name": "Administrator",
+		"username": "root",
+		"avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
+	    },
+	    "runner": null,
+	    "artifacts_file":{
+		"filename": null,
+		"size": null
+	    }
+	}
+    ]
+}


### PR DESCRIPTION
This PR adds support to parse pipeline webhook payloads.

I took the example payload from [the documentation](https://po-gitlab.poinfra.server.lan/help/user/project/integrations/webhooks#pipeline-events) without pruning what isn't required for testing.

