### PR TITLE
Add commit status API

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -1,0 +1,52 @@
+package gogitlab
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	commit_status = "/projects/:id/repository/commits/:sha/statuses" // Get the statuses of a commit in a project
+)
+
+type CommitStatus struct {
+	Status       string     `json:"status"`
+	CreatedAt    time.Time  `json:"created_at"`
+	StartedAt    *time.Time `json:"started_at"`
+	Name         string     `json:"name"`
+	AllowFailure bool       `json:"allow_failure"`
+	Author       Author     `json:"author"`
+	Description  *string    `json:"description"`
+	Sha          string     `json:"sha"`
+	TargetURL    string     `json:"target_url"`
+	FinishedAt   *time.Time `json:"finished_at"`
+	ID           int        `json:"id"`
+	Ref          string     `json:"ref"`
+}
+
+type Author struct {
+	Username  string `json:"username"`
+	State     string `json:"state"`
+	WebURL    string `json:"web_url"`
+	AvatarURL string `json:"avatar_url"`
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+}
+
+func (g *Gitlab) ProjectCommitStatuses(id, sha1 string) ([]*CommitStatus, error) {
+	url, opaque := g.ResourceUrlRaw(commit_status, map[string]string{
+		":id":  id,
+		":sha": sha1,
+	})
+
+	statuses := make([]*CommitStatus, 0)
+
+	contents, err := g.buildAndExecRequestRaw("GET", url, opaque, nil)
+	if err != nil {
+		return statuses, err
+	}
+
+	err = json.Unmarshal(contents, &statuses)
+
+	return statuses, err
+}

--- a/commits.go
+++ b/commits.go
@@ -15,22 +15,13 @@ type CommitStatus struct {
 	StartedAt    *time.Time `json:"started_at"`
 	Name         string     `json:"name"`
 	AllowFailure bool       `json:"allow_failure"`
-	Author       Author     `json:"author"`
+	Author       User       `json:"author"`
 	Description  *string    `json:"description"`
 	Sha          string     `json:"sha"`
 	TargetURL    string     `json:"target_url"`
 	FinishedAt   *time.Time `json:"finished_at"`
 	ID           int        `json:"id"`
 	Ref          string     `json:"ref"`
-}
-
-type Author struct {
-	Username  string `json:"username"`
-	State     string `json:"state"`
-	WebURL    string `json:"web_url"`
-	AvatarURL string `json:"avatar_url"`
-	ID        int    `json:"id"`
-	Name      string `json:"name"`
 }
 
 func (g *Gitlab) ProjectCommitStatuses(id, sha1 string) ([]*CommitStatus, error) {

--- a/commits_test.go
+++ b/commits_test.go
@@ -1,0 +1,33 @@
+package gogitlab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectCommitStatuses(t *testing.T) {
+	ts, gitlab := Stub("stubs/commits/statuses.json")
+	defer ts.Close()
+
+	statuses, err := gitlab.ProjectCommitStatuses("1", "18f3e63d05582537db6d183d9d557be09e1f90c8")
+
+	assert.Nil(t, err)
+	assert.Equal(t, len(statuses), 2)
+
+	assert.Equal(t, statuses[0].Author.Username, "thedude")
+	assert.Equal(t, statuses[0].Author.Name, "Jeff Lebowski")
+	assert.Equal(t, statuses[0].Name, "bundler:audit")
+	assert.Equal(t, statuses[0].Status, "pending")
+	assert.Equal(t, statuses[0].ID, 91)
+	assert.Equal(t, statuses[0].Sha, "18f3e63d05582537db6d183d9d557be09e1f90c8")
+	assert.Equal(t, statuses[0].TargetURL, "https://gitlab.example.com/thedude/gitlab-ce/builds/91")
+
+	assert.Equal(t, statuses[1].Author.Username, "thedude")
+	assert.Equal(t, statuses[1].Author.Name, "Jeff Lebowski")
+	assert.Equal(t, statuses[1].Name, "flay")
+	assert.Equal(t, statuses[1].Status, "pending")
+	assert.Equal(t, statuses[1].ID, 90)
+	assert.Equal(t, statuses[1].Sha, "18f3e63d05582537db6d183d9d557be09e1f90c8")
+	assert.Equal(t, statuses[1].TargetURL, "https://gitlab.example.com/thedude/gitlab-ce/builds/90")
+}

--- a/stubs/commits/statuses.json
+++ b/stubs/commits/statuses.json
@@ -1,0 +1,44 @@
+[
+   {
+      "status" : "pending",
+      "created_at" : "2016-01-19T08:40:25.934Z",
+      "started_at" : null,
+      "name" : "bundler:audit",
+      "allow_failure" : true,
+      "author" : {
+         "username" : "thedude",
+         "state" : "active",
+         "web_url" : "https://gitlab.example.com/thedude",
+         "avatar_url" : "https://gitlab.example.com/uploads/user/avatar/28/The-Big-Lebowski-400-400.png",
+         "id" : 28,
+         "name" : "Jeff Lebowski"
+      },
+      "description" : null,
+      "sha" : "18f3e63d05582537db6d183d9d557be09e1f90c8",
+      "target_url" : "https://gitlab.example.com/thedude/gitlab-ce/builds/91",
+      "finished_at" : null,
+      "id" : 91,
+      "ref" : "master"
+   },
+   {
+      "started_at" : null,
+      "name" : "flay",
+      "allow_failure" : false,
+      "status" : "pending",
+      "created_at" : "2016-01-19T08:40:25.832Z",
+      "target_url" : "https://gitlab.example.com/thedude/gitlab-ce/builds/90",
+      "id" : 90,
+      "finished_at" : null,
+      "ref" : "master",
+      "sha" : "18f3e63d05582537db6d183d9d557be09e1f90c8",
+      "author" : {
+         "id" : 28,
+         "name" : "Jeff Lebowski",
+         "username" : "thedude",
+         "web_url" : "https://gitlab.example.com/thedude",
+         "state" : "active",
+         "avatar_url" : "https://gitlab.example.com/uploads/user/avatar/28/The-Big-Lebowski-400-400.png"
+      },
+      "description" : null
+   }
+]

--- a/users.go
+++ b/users.go
@@ -22,6 +22,7 @@ type User struct {
 	Skype         string `json:"skype,omitempty"`
 	LinkedIn      string `json:"linkedin,omitempty"`
 	Twitter       string `json:"twitter,omitempty"`
+	WebURL        string `json:"web_url"`
 	ExternUid     string `json:"extern_uid,omitempty"`
 	Provider      string `json:"provider,omitempty"`
 	ThemeId       int    `json:"theme_id,omitempty"`


### PR DESCRIPTION
This API was introduced in GitLab 8.1 to lookup the commit status: https://docs.gitlab.com/ce/api/commits.html#commit-status