### PR TITLE
Use hp.ObjectKind as expression in payload switch

### DIFF
--- a/hook_payload.go
+++ b/hook_payload.go
@@ -86,18 +86,14 @@ func ParseHook(payload []byte) (*HookPayload, error) {
 	}
 
 	// Basic sanity check
-	switch {
-	case len(hp.ObjectKind) == 0:
-		// Assume this is a post-receive within repository
-		if len(hp.After) == 0 {
-			return nil, fmt.Errorf("Invalid hook received, commit hash not found.")
-		}
+	switch hp.ObjectKind {
+	case "push":
 		break
-	case hp.ObjectKind == "pipeline":
+	case "pipeline":
 		break
-	case hp.ObjectKind == "issue":
+	case "issue":
 		break
-	case hp.ObjectKind == "merge_request":
+	case "merge_request":
 		if hp.ObjectAttributes == nil {
 			return nil, fmt.Errorf("Invalid hook received, attributes not found.")
 		}

--- a/hook_payload.go
+++ b/hook_payload.go
@@ -92,14 +92,16 @@ func ParseHook(payload []byte) (*HookPayload, error) {
 		if len(hp.After) == 0 {
 			return nil, fmt.Errorf("Invalid hook received, commit hash not found.")
 		}
+		break
 	case hp.ObjectKind == "pipeline":
-		fallthrough
+		break
 	case hp.ObjectKind == "issue":
-		fallthrough
+		break
 	case hp.ObjectKind == "merge_request":
 		if hp.ObjectAttributes == nil {
 			return nil, fmt.Errorf("Invalid hook received, attributes not found.")
 		}
+		break
 	default:
 		return nil, fmt.Errorf("Invalid hook received, payload format not recognized.")
 	}

--- a/stubs/hooks/push.json
+++ b/stubs/hooks/push.json
@@ -1,4 +1,5 @@
 {
+  "object_kind": "push",
   "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
   "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
   "ref": "refs/heads/master",


### PR DESCRIPTION
The second commit, for `hp.ObjectKind`, requires the first commit to properly exit the switch.

I haven't noticed it before, but at least now, with 9.1.0, all payloads
contain the `object_kind` member. Hence the PR.