### PR TITLE
Create Project API

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -18,7 +18,7 @@ type Group struct {
 	Name                      string     `json:"name,omitempty"`
 	Path                      string     `json:"path,omitempty"`
 	Description               string     `json:"description,omitempty"`
-	Visibility                string     `json:"visibility,omitempty"`
+	Visibility                Visibility `json:"visibility,omitempty"`
 	LfsEnabled                bool       `json:"lfs_enabled,omitempty"`
 	AvatarUrl                 string     `json:"avatar_url,omitempty"`
 	WebURL                    string     `json:"web_url,omitempty"`

--- a/groups_test.go
+++ b/groups_test.go
@@ -42,7 +42,7 @@ func TestAddGroup(t *testing.T) {
 		Name:                 "New Group",
 		Path:                 "new-group",
 		Description:          "A new group added for testing",
-		Visibility:           "internal",
+		Visibility:           VisibilityInternal,
 		LfsEnabled:           true,
 		RequestAccessEnabled: true,
 	})
@@ -51,7 +51,7 @@ func TestAddGroup(t *testing.T) {
 	assert.Equal(t, result.Name, "New Group")
 	assert.Equal(t, result.Path, "new-group")
 	assert.Equal(t, result.Description, "A new group added for testing")
-	assert.Equal(t, result.Visibility, "internal")
+	assert.Equal(t, result.Visibility, VisibilityInternal)
 	assert.Equal(t, result.LfsEnabled, true)
 	assert.Equal(t, result.RequestAccessEnabled, true)
 }

--- a/projects.go
+++ b/projects.go
@@ -66,6 +66,7 @@ type Project struct {
 	WikiEnabled          bool       `json:"wiki_enabled,omitempty"`
 	CreatedAtRaw         string     `json:"created_at,omitempty"`
 	Namespace            *Namespace `json:"namespace,omitempty"`
+	NamespaceId          int        `json:"namespace_id,omitempty"` // Only used for create
 	SshRepoUrl           string     `json:"ssh_url_to_repo"`
 	HttpRepoUrl          string     `json:"http_url_to_repo"`
 	WebUrl               string     `json:"web_url"`
@@ -97,6 +98,29 @@ Get a list of all GitLab projects (admin only).
 */
 func (g *Gitlab) AllProjects() ([]*Project, error) {
 	return projects(projects_all, g)
+}
+
+/*
+Creates a new project owned by the authenticated user.
+
+One (or more) of the following fields are required:
+	* Name
+	* Path
+*/
+func (g *Gitlab) AddProject(project *Project) (*Project, error) {
+	url := g.ResourceUrl(projects_url, nil)
+
+	encodedRequest, err := json.Marshal(project)
+	if err != nil {
+		return nil, err
+	}
+	var result *Project
+	contents, err := g.buildAndExecRequest("POST", url, encodedRequest)
+	if err == nil {
+		err = json.Unmarshal(contents, &result)
+	}
+
+	return result, err
 }
 
 /*

--- a/projects.go
+++ b/projects.go
@@ -36,6 +36,19 @@ type Namespace struct {
 	Updated_At  string
 }
 
+type Visibility string
+
+const (
+	// VisibilityPrivate indicates project access must be granted explicitly for each user.
+	VisibilityPrivate = Visibility("private")
+
+	// VisibilityInternal indicates the project can be cloned by any logged in user.
+	VisibilityInternal = Visibility("internal")
+
+	// VisibilityPublic indicates the project can be cloned without any authentication.
+	VisibilityPublic = Visibility("public")
+)
+
 // A gitlab project
 type Project struct {
 	Id                   int        `json:"id,omitempty"`
@@ -46,6 +59,7 @@ type Project struct {
 	Public               bool       `json:"public,omitempty"`
 	Path                 string     `json:"path,omitempty"`
 	PathWithNamespace    string     `json:"path_with_namespace,omitempty"`
+	Visibility           Visibility `json:"visibility,omitempty"`
 	IssuesEnabled        bool       `json:"issues_enabled,omitempty"`
 	MergeRequestsEnabled bool       `json:"merge_requests_enabled,omitempty"`
 	WallEnabled          bool       `json:"wall_enabled,omitempty"`

--- a/projects_test.go
+++ b/projects_test.go
@@ -26,6 +26,26 @@ func TestProject(t *testing.T) {
 	defer ts.Close()
 }
 
+func TestAddProject(t *testing.T) {
+	ts, gitlab := Stub("stubs/projects/add.json")
+	defer ts.Close()
+
+	project := &Project{
+		Name:        "Diaspora Client",
+		Path:        "diaspora-client",
+		NamespaceId: 3,
+		Visibility:  VisibilityPrivate,
+	}
+	newProject, err := gitlab.AddProject(project)
+
+	assert.NoError(t, err)
+	assert.Equal(t, newProject.Name, project.Name)
+	assert.Equal(t, newProject.Description, project.Description)
+	assert.Equal(t, newProject.SshRepoUrl, "git@example.com:diaspora/diaspora-client.git")
+	assert.Equal(t, newProject.HttpRepoUrl, "http://example.com/diaspora/diaspora-client.git")
+	assert.Equal(t, newProject.WebUrl, "http://example.com/diaspora/diaspora-client")
+}
+
 func TestUpdateProject(t *testing.T) {
 	ts, gitlab := Stub("stubs/projects/show.json")
 	project := Project{

--- a/stubs/projects/add.json
+++ b/stubs/projects/add.json
@@ -1,0 +1,59 @@
+{
+  "id": 4,
+  "description": null,
+  "default_branch": "master",
+  "visibility": "private",
+  "ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",
+  "http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",
+  "web_url": "http://example.com/diaspora/diaspora-client",
+  "tag_list": [
+    "example",
+    "disapora client"
+  ],
+  "owner": {
+    "id": 3,
+    "name": "Diaspora",
+    "created_at": "2013-09-30T13:46:02Z"
+  },
+  "name": "Diaspora Client",
+  "name_with_namespace": "Diaspora / Diaspora Client",
+  "path": "diaspora-client",
+  "path_with_namespace": "diaspora/diaspora-client",
+  "issues_enabled": true,
+  "open_issues_count": 1,
+  "merge_requests_enabled": true,
+  "jobs_enabled": true,
+  "wiki_enabled": true,
+  "snippets_enabled": false,
+  "container_registry_enabled": false,
+  "created_at": "2013-09-30T13:46:02Z",
+  "last_activity_at": "2013-09-30T13:46:02Z",
+  "creator_id": 3,
+  "namespace": {
+    "id": 3,
+    "name": "Diaspora",
+    "path": "diaspora",
+    "kind": "group",
+    "full_path": "diaspora"
+  },
+  "import_status": "none",
+  "archived": false,
+  "avatar_url": "http://example.com/uploads/project/avatar/4/uploads/avatar.png",
+  "shared_runners_enabled": true,
+  "forks_count": 0,
+  "star_count": 0,
+  "runners_token": "b8547b1dc37721d05889db52fa2f02",
+  "public_jobs": true,
+  "shared_with_groups": [],
+  "only_allow_merge_if_pipeline_succeeds": false,
+  "only_allow_merge_if_all_discussions_are_resolved": false,
+  "request_access_enabled": false,
+  "approvals_before_merge": 0,
+  "statistics": {
+    "commit_count": 37,
+    "storage_size": 1038090,
+    "repository_size": 1038090,
+    "lfs_objects_size": 0,
+    "job_artifacts_size": 0
+  }
+}


### PR DESCRIPTION
Adds API to create a project. 

This would supersede PR #38 which seems to be abandoned. 